### PR TITLE
harden: don't mount the ServiceAccount token into agent pods by default

### DIFF
--- a/src/k8s_sandbox/resources/helm/agent-env/README.md
+++ b/src/k8s_sandbox/resources/helm/agent-env/README.md
@@ -11,6 +11,7 @@
 | allowDomains | list | Empty list (no internet access) | A list of fully qualified domain names that pods within the agent environment are allowed to access. |
 | allowEntities | list | Empty list (no additional entities compared to default policies) | A list of Cilium entities (e.g. "world") that pods within the agent environment are allowed to access. |
 | annotations | object | `{}` | A dict of annotations to apply to resources within the agent environment. |
+| automountServiceAccountToken | string | false (true when serviceAccountName is set) | Whether to mount the ServiceAccount token into agent pods. Agent code has no reason to reach the Kubernetes API, so this defaults to false. Left unset it resolves to false, or true when `serviceAccountName` is set (an explicitly requested identity). Set it explicitly to override either way. |
 | corednsCommand | list | `["/coredns","-conf","/etc/coredns/Corefile"]` | The command to use for the coredns container. |
 | corednsImage | string | `"coredns/coredns:1.8.3"` | The image to use for the coredns container. |
 | global | object | set by inspect | The name of the agent environment, only overwrite in cases where e.g. name lengths are causing failures. |

--- a/src/k8s_sandbox/resources/helm/agent-env/templates/services.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/services.yaml
@@ -36,6 +36,17 @@ spec:
       {{- if $.Values.serviceAccountName }}
       serviceAccountName: {{ $.Values.serviceAccountName }}
       {{- end }}
+      {{- /* Agent code has no reason to reach the Kubernetes API, so don't mount a
+             token for it. Unset means: false, unless serviceAccountName was given
+             (the operator asked for an identity, so preserve that behaviour).
+             kindIs, not `default`, because `default` treats false as empty. */}}
+      {{- if kindIs "bool" $.Values.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ $.Values.automountServiceAccountToken }}
+      {{- else if $.Values.serviceAccountName }}
+      automountServiceAccountToken: true
+      {{- else }}
+      automountServiceAccountToken: false
+      {{- end }}
       {{- /* Do not leak info on services via env vars */}}
       enableServiceLinks: false
       terminationGracePeriodSeconds: 0

--- a/src/k8s_sandbox/resources/helm/agent-env/values.schema.json
+++ b/src/k8s_sandbox/resources/helm/agent-env/values.schema.json
@@ -147,16 +147,41 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "name": {"type": "string"},
-                  "image": {"type": "string"},
-                  "command": { "type": "array", "items": { "type": "string" } },
-                  "args": { "type": "array", "items": { "type": "string" } },
-                  "imagePullPolicy": {"type": "string"},
-                  "workingDir": {"type": "string"},
-                  "resources": {"type": "object"},
-                  "securityContext": {"type": "object"}
+                  "name": {
+                    "type": "string"
+                  },
+                  "image": {
+                    "type": "string"
+                  },
+                  "command": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "args": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "imagePullPolicy": {
+                    "type": "string"
+                  },
+                  "workingDir": {
+                    "type": "string"
+                  },
+                  "resources": {
+                    "type": "object"
+                  },
+                  "securityContext": {
+                    "type": "object"
+                  }
                 },
-                "required": ["name", "image"]
+                "required": [
+                  "name",
+                  "image"
+                ]
               }
             }
           },
@@ -205,7 +230,17 @@
       "type": "object"
     },
     "serviceAccountName": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "automountServiceAccountToken": {
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "description": "Mount the ServiceAccount token into agent pods. Defaults to false (true when serviceAccountName is set)."
     }
   },
   "required": [

--- a/src/k8s_sandbox/resources/helm/agent-env/values.schema.json
+++ b/src/k8s_sandbox/resources/helm/agent-env/values.schema.json
@@ -147,41 +147,16 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "image": {
-                    "type": "string"
-                  },
-                  "command": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "args": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "imagePullPolicy": {
-                    "type": "string"
-                  },
-                  "workingDir": {
-                    "type": "string"
-                  },
-                  "resources": {
-                    "type": "object"
-                  },
-                  "securityContext": {
-                    "type": "object"
-                  }
+                  "name": {"type": "string"},
+                  "image": {"type": "string"},
+                  "command": { "type": "array", "items": { "type": "string" } },
+                  "args": { "type": "array", "items": { "type": "string" } },
+                  "imagePullPolicy": {"type": "string"},
+                  "workingDir": {"type": "string"},
+                  "resources": {"type": "object"},
+                  "securityContext": {"type": "object"}
                 },
-                "required": [
-                  "name",
-                  "image"
-                ]
+                "required": ["name", "image"]
               }
             }
           },
@@ -230,17 +205,10 @@
       "type": "object"
     },
     "serviceAccountName": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "automountServiceAccountToken": {
-      "type": [
-        "boolean",
-        "null"
-      ],
-      "description": "Mount the ServiceAccount token into agent pods. Defaults to false (true when serviceAccountName is set)."
+      "type": ["boolean", "null"]
     }
   },
   "required": [

--- a/src/k8s_sandbox/resources/helm/agent-env/values.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/values.yaml
@@ -145,7 +145,8 @@ annotations:
 # -- A dict of labels to apply to resources within the agent environment.
 labels: {}
 # -- Service account name. When set, a ServiceAccount is created with this name
-# and pods will use it.
+# and pods will use it. This must be a ServiceAccount name which doesn't already
+# exist.
 serviceAccountName: null
 # -- Whether to mount the ServiceAccount token into agent pods. Agent code has no
 # reason to reach the Kubernetes API, so this defaults to false. Left unset it

--- a/src/k8s_sandbox/resources/helm/agent-env/values.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/values.yaml
@@ -147,3 +147,9 @@ labels: {}
 # -- Service account name. When set, a ServiceAccount is created with this name
 # and pods will use it.
 serviceAccountName: null
+# -- Whether to mount the ServiceAccount token into agent pods. Agent code has no
+# reason to reach the Kubernetes API, so this defaults to false. Left unset it
+# resolves to false, or true when `serviceAccountName` is set (an explicitly
+# requested identity). Set it explicitly to override either way.
+# @default -- false (true when serviceAccountName is set)
+automountServiceAccountToken: null

--- a/test/k8s_sandbox/helm_chart/resources/automount-explicit-true-values.yaml
+++ b/test/k8s_sandbox/helm_chart/resources/automount-explicit-true-values.yaml
@@ -1,0 +1,1 @@
+automountServiceAccountToken: true

--- a/test/k8s_sandbox/helm_chart/resources/automount-sa-explicit-false-values.yaml
+++ b/test/k8s_sandbox/helm_chart/resources/automount-sa-explicit-false-values.yaml
@@ -1,0 +1,2 @@
+serviceAccountName: my-sa
+automountServiceAccountToken: false

--- a/test/k8s_sandbox/helm_chart/resources/automount-with-sa-values.yaml
+++ b/test/k8s_sandbox/helm_chart/resources/automount-with-sa-values.yaml
@@ -1,0 +1,1 @@
+serviceAccountName: my-sa

--- a/test/k8s_sandbox/helm_chart/test_helm_chart.py
+++ b/test/k8s_sandbox/helm_chart/test_helm_chart.py
@@ -495,7 +495,9 @@ def _get_documents(documents: list[Any], doc_type_filter: str) -> list[dict[str,
     [
         pytest.param(None, False, id="default_withholds_token"),
         pytest.param("automount-explicit-true-values.yaml", True, id="explicit_true"),
-        pytest.param("automount-with-sa-values.yaml", True, id="service_account_opts_in"),
+        pytest.param(
+            "automount-with-sa-values.yaml", True, id="service_account_opts_in"
+        ),
         # `default` in Helm treats false as empty, so an explicit false must not
         # fall through to the serviceAccountName branch.
         pytest.param(

--- a/test/k8s_sandbox/helm_chart/test_helm_chart.py
+++ b/test/k8s_sandbox/helm_chart/test_helm_chart.py
@@ -488,3 +488,37 @@ def _run_helm_template(
 
 def _get_documents(documents: list[Any], doc_type_filter: str) -> list[dict[str, Any]]:
     return [doc for doc in documents if doc["kind"] == doc_type_filter]
+
+
+@pytest.mark.parametrize(
+    ("values_file", "expected"),
+    [
+        pytest.param(None, False, id="default_withholds_token"),
+        pytest.param("automount-explicit-true-values.yaml", True, id="explicit_true"),
+        pytest.param("automount-with-sa-values.yaml", True, id="service_account_opts_in"),
+        # `default` in Helm treats false as empty, so an explicit false must not
+        # fall through to the serviceAccountName branch.
+        pytest.param(
+            "automount-sa-explicit-false-values.yaml",
+            False,
+            id="explicit_false_beats_service_account",
+        ),
+    ],
+)
+def test_automount_service_account_token(
+    chart_dir: Path,
+    test_resources_dir: Path,
+    values_file: str | None,
+    expected: bool,
+) -> None:
+    documents = _run_helm_template(
+        chart_dir,
+        test_resources_dir / values_file if values_file else None,
+    )
+
+    services = _get_documents(documents, "StatefulSet")
+
+    assert (
+        services[0]["spec"]["template"]["spec"]["automountServiceAccountToken"]
+        is expected
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P1W"
+
 [[package]]
 name = "aioboto3"
 version = "15.5.0"
@@ -482,7 +486,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -6,10 +6,6 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P1W"
-
 [[package]]
 name = "aioboto3"
 version = "15.5.0"
@@ -486,7 +482,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
## What

Agent pods get the namespace `default` ServiceAccount's token mounted at `/var/run/secrets/kubernetes.io/serviceaccount/token`. They run untrusted, model-generated code and have no reason to reach the Kubernetes API. This withholds the token by default.

Confirmed present in a live sandbox pod while auditing sandbox isolation.

## Why it's worth doing even though it's currently harmless

Impact today is capped: the `default` SA has no RBAC bindings, and the per-sandbox egress policy blocks the API server, so a mounted token buys an attacker nothing. But that is two independent conditions holding — bind any RBAC to `default`/`system:authenticated`, or open egress (as a cyber eval deliberately does), and it becomes a real pivot. Removing it costs nothing and makes the guarantee unconditional.

Same class of hardening as the `enableServiceLinks: false` line directly below it.

## Behaviour

| `automountServiceAccountToken` | `serviceAccountName` | Result |
|---|---|---|
| unset | unset | `false` ← **new default** |
| unset | set | `true` (unchanged — an explicitly requested identity) |
| `true` | any | `true` |
| `false` | any | `false` |

No change for anyone using `serviceAccountName`.

## Implementation note

Uses `kindIs "bool"` rather than `default`. Helm's `default` treats `false` as empty, so `automountServiceAccountToken: false` combined with a `serviceAccountName` would fall through to the "identity requested" branch and silently mount the token — the opposite of what was asked. There's a test pinning that case specifically.

## Testing

`test_automount_service_account_token`, 4 cases: default withholds; explicit `true`; `serviceAccountName` opts in; explicit `false` beats `serviceAccountName`.

```
4 passed    # new
27 passed   # full test_helm_chart.py
```

## Base branch

Targeting `hotfix` rather than `main`, since that's the branch consumers pin (`main` is 26 commits behind it).